### PR TITLE
Make AbCache `fsspec` compliant

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,9 +46,9 @@
                 "--app-region",
                 "jp",
                 "--app-version",
-                "4.0.5",
+                "4.1.0",
                 "--app-appHash",
-                "2179da72-9de5-23a6-f388-9e5835098ce1"
+                "cbda2f12-c804-4163-5e11-3148631f9ab0"
             ],
             "justMyCode": true
         },
@@ -128,6 +128,18 @@
             "justMyCode": true
         },
         {
+            "name": "Python: AbServer",
+            "type": "python",
+            "request": "launch",
+            "module": "sssekai",
+            "args": [
+                "--log-level",
+                "DEBUG",
+                "abserver"               
+            ],
+            "justMyCode": false
+        },        
+        {
             "name": "Python: AbCache (no update)",
             "type": "python",
             "request": "launch",
@@ -139,12 +151,12 @@
                 "--no-update",
                 "--download-dir",
                 "~/.sssekai/bundles/",
-                "--download-ensure-deps",
                 "--download-filter",
-                ".*characterv2/face/21/.*"
+                ".*characterv2/face/21/0000"
             ],
             "justMyCode": true
         },
+        
         {
             "name": "Python: MVData",
             "type": "python",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -128,6 +128,22 @@
             "justMyCode": true
         },
         {
+            "name": "Python: AbServer (FUSE)",
+            "type": "python",
+            "request": "launch",
+            "module": "sssekai",
+            "args": [
+                "--log-level",
+                "DEBUG",
+                "abserver",
+                "--db",
+                "/mnt/c/Users/mos9527/.sssekai/abcache.db",
+                "--fuse",
+                "/mnt/abcache"
+            ],
+            "justMyCode": false
+        },   
+        {
             "name": "Python: AbServer",
             "type": "python",
             "request": "launch",
@@ -136,10 +152,11 @@
                 "--log-level",
                 "DEBUG",
                 "abserver",
-                "--fuse"
+                "--db",
+                "/mnt/c/Users/mos9527/.sssekai/abcache.db",
             ],
             "justMyCode": false
-        },        
+        },                
         {
             "name": "Python: AbCache (no update)",
             "type": "python",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -135,7 +135,8 @@
             "args": [
                 "--log-level",
                 "DEBUG",
-                "abserver"               
+                "abserver",
+                "--fuse"
             ],
             "justMyCode": false
         },        
@@ -154,7 +155,7 @@
                 "--download-filter",
                 ".*characterv2/face/21/0000"
             ],
-            "justMyCode": true
+            "justMyCode": false
         },
         
         {

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setuptools.setup(
         "requests",
         "pyaxmlparser",
     ],
-    entry_points={"console_scripts": ["sssekai = sssekai.__main__:__main__"]},
+    entry_points={
+        "console_scripts": ["sssekai = sssekai.__main__:__main__"],
+        "fsspec.specs": ["abcache = sssekai.abcache.fs.AbCacheFilesystem"],
+    },
     python_requires=">=3.10",
 )

--- a/sssekai/__main__.py
+++ b/sssekai/__main__.py
@@ -164,13 +164,31 @@ This crypto applies to:
     )
     abcache_parser.set_defaults(func=main_abcache)
     abserver_parser = subparsers.add_parser(
-        "abserver", help="""AbCache Filesystem server"""
+        "abserver", help="""AbCache Filesystem server / GUI"""
     )
     abserver_parser.add_argument(
         "--db",
         type=str,
         help="""cache database file path (default: %(default)s)""",
         default=DEFAULT_CACHE_DB_FILE,
+    )
+    abserver_parser.add_argument(
+        "--fuse",
+        type=str,
+        help="""local mount point for AbCache. Required FUSE on host OS and fusepy (default: %(default)s)""",
+        default="",
+    )
+    abserver_parser.add_argument(
+        "--host",
+        type=str,
+        help="""address of the interface to listen on (default: %(default)s)""",
+        default="0.0.0.0",
+    )
+    abserver_parser.add_argument(
+        "--port",
+        type=int,
+        help="""port to listen on (default: %(default)d)""",
+        default="3939",
     )
     abserver_parser.set_defaults(func=main_abserver)
     # live2dextract

--- a/sssekai/__main__.py
+++ b/sssekai/__main__.py
@@ -6,6 +6,7 @@ from sssekai.entrypoint.abdecrypt import main_abdecrypt
 from sssekai.entrypoint.rla2json import main_rla2json
 from sssekai.entrypoint.usmdemux import main_usmdemux
 from sssekai.entrypoint.abcache import main_abcache, DEFAULT_CACHE_DB_FILE
+from sssekai.entrypoint.abserver import main_abserver
 from sssekai.entrypoint.live2dextract import main_live2dextract
 from sssekai.entrypoint.spineextract import main_spineextract
 from sssekai.entrypoint.apphash import main_apphash
@@ -27,10 +28,7 @@ def __main__():
                 return sys.stdout.write(__s)
 
     parser = argparse.ArgumentParser(
-        description="""SSSekai Proejct SEKAI feat. Hatsune Miku (Android) Modding Tools
-Installation:
-    pip install sssekai                                    
-""",
+        description="""SSSekai Proejct SEKAI feat. Hatsune Miku (Android) Asset Utility""",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
@@ -165,6 +163,16 @@ This crypto applies to:
         default=None,
     )
     abcache_parser.set_defaults(func=main_abcache)
+    abserver_parser = subparsers.add_parser(
+        "abserver", help="""AbCache Filesystem server"""
+    )
+    abserver_parser.add_argument(
+        "--db",
+        type=str,
+        help="""cache database file path (default: %(default)s)""",
+        default=DEFAULT_CACHE_DB_FILE,
+    )
+    abserver_parser.set_defaults(func=main_abserver)
     # live2dextract
     live2dextract_parser = subparsers.add_parser(
         "live2dextract", help="""Extract Sekai Live2D Models in a AssetBundle"""

--- a/sssekai/abcache/__init__.py
+++ b/sssekai/abcache/__init__.py
@@ -474,10 +474,11 @@ class AbCache(Session):
     def load(self, f: BinaryIO):
         logger.debug("Loading cache")
         self.database = load(f)
+        logger.debug("Cache loaded: %s" % self)
 
     def __repr__(self) -> str:
         return (
-            f"<AbCache config={self.config} bundles={len(self.abcache_index.bundles)}>"
+            f"AbCache(config={self.config} bundles={len(self.abcache_index.bundles)})"
         )
 
     def get_entry_by_bundle_name(self, bundleName: str) -> AbCacheEntry:

--- a/sssekai/abcache/__init__.py
+++ b/sssekai/abcache/__init__.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from pickle import load, dump
 from typing import BinaryIO, List, Mapping, Optional, Union
 from logging import getLogger
@@ -400,25 +401,26 @@ class AbCache(Session):
         self.database.sekai_abcache_index = fromdict(AbCacheIndex, data)
         return self.database.sekai_abcache_index
 
-    def __init__(self, config: AbCacheConfig) -> None:
+    def __init__(self, config: Optional[AbCacheConfig] = None):
         super().__init__()
         self.database = SSSekaiDatabase()
-        self.config = config
-        self.config.app_platform = self.config.app_platform.lower()
-        self.headers.update(
-            {
-                "Accept": "application/octet-stream",
-                "Content-Type": "application/octet-stream",
-                "Accept-Encoding": "deflate, gzip",
-                "User-Agent": "UnityPlayer/%s" % sssekai_get_unity_version(),
-                "X-Platform": self.config.app_platform.capitalize(),
-                "X-DeviceModel": "sssekai/%s" % __version__,
-                "X-OperatingSystem": self.config.app_platform.capitalize(),
-                "X-Unity-Version": sssekai_get_unity_version(),
-                "X-App-Version": self.SEKAI_APP_VERSION,
-                "X-App-Hash": self.SEKAI_APP_HASH,
-            }
-        )
+        if config is not None:
+            self.config = config
+            self.config.app_platform = self.config.app_platform.lower()
+            self.headers.update(
+                {
+                    "Accept": "application/octet-stream",
+                    "Content-Type": "application/octet-stream",
+                    "Accept-Encoding": "deflate, gzip",
+                    "User-Agent": "UnityPlayer/%s" % sssekai_get_unity_version(),
+                    "X-Platform": self.config.app_platform.capitalize(),
+                    "X-DeviceModel": "sssekai/%s" % __version__,
+                    "X-OperatingSystem": self.config.app_platform.capitalize(),
+                    "X-Unity-Version": sssekai_get_unity_version(),
+                    "X-App-Version": self.SEKAI_APP_VERSION,
+                    "X-App-Hash": self.SEKAI_APP_HASH,
+                }
+            )
 
     def update_download_headers(self):
         """Update headers for downloading assetbundles *ONLY*. Functionalities related to user-level data (e.g. Master Data, etc) won't

--- a/sssekai/abcache/fs.py
+++ b/sssekai/abcache/fs.py
@@ -1,49 +1,96 @@
+import math, fsspec
+from typing import Callable
 from functools import cached_property
 from collections import defaultdict
 from fsspec.spec import AbstractBufferedFile
+from fsspec.caching import BaseCache, register_cache
 from fsspec.archive import AbstractArchiveFileSystem
 from requests import Response
+from logging import getLogger
+from sssekai.crypto.AssetBundle import decrypt_iter
 from . import AbCache, AbCacheEntry
-from sssekai.crypto.AssetBundle import SEKAI_AB_MAGIC, decrypt_header_inplace
+
+logger = getLogger("abcache.fs")
+
+
+# Reference: https://github.com/fsspec/filesystem_spec/blame/master/fsspec/caching.py
+class UnidirectionalBlockCache(BaseCache):
+    """Block-based cache that only fetches data in one direction with a fixed block size"""
+
+    name: str = "unidirectional_blockcache"
+
+    def __init__(
+        self, blocksize: int, fetcher: Callable[[int, int], bytes], size: int
+    ) -> None:
+        super().__init__(blocksize, fetcher, size)
+        self.nblocks = math.ceil(size / self.blocksize)
+        self.blocks = list()
+
+    def __fetch_block(self, block_number):
+        assert block_number < self.nblocks, "block out of range"
+        while len(self.blocks) - 1 < block_number:
+            logger.debug("Fetching block %d" % (len(self.blocks) - 1))
+            start = self.blocksize * len(self.blocks)
+            end = start + self.blocksize
+            block = self.fetcher(start, end)
+            self.blocks.append(block)
+        return self.blocks[block_number]
+
+    def _fetch(self, start: int | None, stop: int | None) -> bytes:
+        if start is None:
+            start = 0
+        if stop is None:
+            stop = self.size
+        if start >= self.size or start >= stop:
+            return b""
+        start_blk, start_pos = start // self.blocksize, start % self.blocksize
+        end_blk, end_pos = stop // self.blocksize, stop % self.blocksize
+
+        if start_blk == end_blk:
+            out = self.__fetch_block(start_blk)[start_pos:end_pos]
+            return out
+        else:
+            out = [self.__fetch_block(start_blk)[start_pos:]]
+            out += [self.__fetch_block(blk) for blk in range(start_blk + 1, end_blk)]
+            out += [self.__fetch_block(end_blk)[:end_pos]]
+            return b"".join(out)
+
+
+register_cache(UnidirectionalBlockCache)
 
 
 # Reference: https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/http.py#L526
-class AbCacheFilesystemStreamingFile(AbstractBufferedFile):
+class AbCacheFile(AbstractBufferedFile):
+    """Cached, file-like object for reading from an AbCache on demand.
+
+    Note:
+        - The fetched content is decrypted on the fly.
+        - Seeks are simulated by read-aheads (by UnidirectionalBlockCache). Meaning seek operations
+          will incur additional download (in-betweens will be cached as well).
+    """
+
+    entry: AbCacheEntry
+
     @property
     def session(self) -> AbCache:
         return self.fs.cache
 
     @property
     def entry(self) -> AbCacheEntry:
-        return self.fs.cache.get_entry_by_bundle_name(self.path)
+        entry = self.session.get_entry_by_bundle_name(self.path)
+        assert entry is not None, "entry not found"
+        return entry
 
-    def __init__(
-        self,
-        fs,
-        path,
-        mode="rb",
-        block_size="default",
-        autocommit=True,
-        cache_type="readahead",
-        cache_options=None,
-        size=None,
-        **kwargs
-    ):
+    def __init__(self, fs, bundle: str):
+        self.fs, self.path = fs, bundle
+        self.fetch_loc = 0
         super().__init__(
             fs,
-            path,
-            mode,
-            block_size,
-            autocommit,
-            cache_type,
-            cache_options,
-            size,
-            **kwargs
+            bundle,
+            mode="rb",
+            cache_type="unidirectional_blockcache",
+            size=self.entry.fileSize,
         )
-        self.size = self.entry.fileSize
-
-    def seek(self, loc, whence=0):
-        raise NotImplementedError  # `shutils.copyfileobj` is your friend!
 
     @cached_property
     def __resp(self) -> Response:
@@ -52,57 +99,70 @@ class AbCacheFilesystemStreamingFile(AbstractBufferedFile):
         return resp
 
     @cached_property
-    def __header(self) -> bytearray:
-        header = next(self.__resp.iter_content(4))
-        if header == SEKAI_AB_MAGIC:
-            header = bytearray(next(self.__resp.iter_content(128)))
-            header = decrypt_header_inplace(header)
-        return header
+    def __fetch(self):
+        def __innner():
+            for block in decrypt_iter(
+                lambda nbytes: next(self.__resp.iter_content(nbytes)), self.blocksize
+            ):
+                yield block
 
-    def read(self, length=-1):
-        assert self.__header
-        if length < 0:
-            length = self.size
-        buffer = bytearray()
-        header_res = max(0, len(self.__header) - self.loc)
-        if header_res:
-            buffer += self.__header[self.loc : self.loc + header_res]
-            self.loc += len(buffer)
-            length -= len(buffer)
-        if length:
-            try:
-                buffer += next(self.__resp.iter_content(length))
-                self.loc += len(buffer)
-            except StopIteration:
-                pass
-        return buffer
+        return __innner()
+
+    def _fetch_range(self, start, end):
+        assert start - self.fetch_loc == 0, "can only fetch sequentially"
+        self.fetch_loc = end
+        return next(self.__fetch)
 
 
 # Reference: https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/libarchive.py
 class AbCacheFilesystem(AbstractArchiveFileSystem):
+    """Filesystem for reading from an AbCache on demand."""
+
+    protocol = "abcache"
     cache: AbCache
 
-    def __init__(self, cache: AbCache):
-        self.cache = cache
+    def __init__(self, fo: str = "", cache_obj: AbCache = None, *args, **kwargs):
+        """Initialize the filesystem with a cache object
+        or a file-like object that contains the cache database file.
+
+        Args:
+            fo (str, optional): the cahce database file object . Defaults to "".
+            cache_obj (AbCache, optional): the cache database. Defaults to None.
+        """
+        if cache_obj:
+            self.cache = cache_obj
+        else:
+            self.cache = AbCache()
+            if isinstance(fo, str):
+                with fsspec.open(fo, "rb") as f:
+                    self.cache.load(f)
+            else:
+                self.cache.load(fo)
+            self.cache.update_download_headers()
 
     @cached_property
     def dir_cache(self):
         cache = defaultdict(dict)
         for path, bundle in self.cache.abcache_index.bundles.items():
-            cache[path] = {"name": bundle.bundleName, "size": bundle.fileSize}
-            path = path.split("/")
-            dirs = path[:-1]
-            for i in range(0, len(dirs)):
-                path = "/".join(dirs[0:i])
-                cache[path] = {"name": path, "size": 0, "type": "directory"}
+            cache.update(
+                {
+                    dirname: {"name": dirname, "size": 0, "type": "directory"}
+                    for dirname in self._all_dirnames([path])
+                }
+            )
+            cache[path] = {
+                "name": bundle.bundleName,
+                "size": bundle.fileSize,
+                "type": "file",
+            }
         return cache
 
     def _get_dirs(self):
         return self.dir_cache
 
-    def open(self, path):
-        entry = self.cache.get_entry_by_bundle_name(path)
-        assert entry is not None, "entry not found"
-        return AbCacheFilesystemStreamingFile(
-            self, path, size=entry.fileSize, entry=entry
-        )
+    def open(self, path, mode="rb"):
+        assert mode == "rb", "only binary read-only mode is supported"
+        return AbCacheFile(self, path)
+
+
+fsspec.register_implementation("abcache", AbCacheFilesystem)

--- a/sssekai/abcache/fs.py
+++ b/sssekai/abcache/fs.py
@@ -1,0 +1,108 @@
+from functools import cached_property
+from collections import defaultdict
+from fsspec.spec import AbstractBufferedFile
+from fsspec.archive import AbstractArchiveFileSystem
+from requests import Response
+from . import AbCache, AbCacheEntry
+from sssekai.crypto.AssetBundle import SEKAI_AB_MAGIC, decrypt_header_inplace
+
+
+# Reference: https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/http.py#L526
+class AbCacheFilesystemStreamingFile(AbstractBufferedFile):
+    @property
+    def session(self) -> AbCache:
+        return self.fs.cache
+
+    @property
+    def entry(self) -> AbCacheEntry:
+        return self.fs.cache.get_entry_by_bundle_name(self.path)
+
+    def __init__(
+        self,
+        fs,
+        path,
+        mode="rb",
+        block_size="default",
+        autocommit=True,
+        cache_type="readahead",
+        cache_options=None,
+        size=None,
+        **kwargs
+    ):
+        super().__init__(
+            fs,
+            path,
+            mode,
+            block_size,
+            autocommit,
+            cache_type,
+            cache_options,
+            size,
+            **kwargs
+        )
+        self.size = self.entry.fileSize
+
+    def seek(self, loc, whence=0):
+        raise NotImplementedError  # `shutils.copyfileobj` is your friend!
+
+    @cached_property
+    def __resp(self) -> Response:
+        url = self.session.get_entry_download_url(self.entry)
+        resp = self.session.get(url, stream=True)
+        return resp
+
+    @cached_property
+    def __header(self) -> bytearray:
+        header = next(self.__resp.iter_content(4))
+        if header == SEKAI_AB_MAGIC:
+            header = bytearray(next(self.__resp.iter_content(128)))
+            header = decrypt_header_inplace(header)
+        return header
+
+    def read(self, length=-1):
+        assert self.__header
+        if length < 0:
+            length = self.size
+        buffer = bytearray()
+        header_res = max(0, len(self.__header) - self.loc)
+        if header_res:
+            buffer += self.__header[self.loc : self.loc + header_res]
+            self.loc += len(buffer)
+            length -= len(buffer)
+        if length:
+            try:
+                buffer += next(self.__resp.iter_content(length))
+                self.loc += len(buffer)
+            except StopIteration:
+                pass
+        return buffer
+
+
+# Reference: https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/libarchive.py
+class AbCacheFilesystem(AbstractArchiveFileSystem):
+    cache: AbCache
+
+    def __init__(self, cache: AbCache):
+        self.cache = cache
+
+    @cached_property
+    def dir_cache(self):
+        cache = defaultdict(dict)
+        for path, bundle in self.cache.abcache_index.bundles.items():
+            cache[path] = {"name": bundle.bundleName, "size": bundle.fileSize}
+            path = path.split("/")
+            dirs = path[:-1]
+            for i in range(0, len(dirs)):
+                path = "/".join(dirs[0:i])
+                cache[path] = {"name": path, "size": 0, "type": "directory"}
+        return cache
+
+    def _get_dirs(self):
+        return self.dir_cache
+
+    def open(self, path):
+        entry = self.cache.get_entry_by_bundle_name(path)
+        assert entry is not None, "entry not found"
+        return AbCacheFilesystemStreamingFile(
+            self, path, size=entry.fileSize, entry=entry
+        )

--- a/sssekai/abcache/fs.py
+++ b/sssekai/abcache/fs.py
@@ -29,7 +29,7 @@ class UnidirectionalBlockCache(BaseCache):
     def __fetch_block(self, block_number):
         assert block_number < self.nblocks, "block out of range"
         while len(self.blocks) - 1 < block_number:
-            logger.debug("Fetching block %d" % (len(self.blocks) - 1))
+            logger.debug("Fetching block %d" % (len(self.blocks)))
             start = self.blocksize * len(self.blocks)
             end = start + self.blocksize
             block = self.fetcher(start, end)
@@ -77,7 +77,7 @@ class AbCacheFile(AbstractBufferedFile):
 
     @property
     def entry(self) -> AbCacheEntry:
-        entry = self.session.get_entry_by_bundle_name(self.path)
+        entry = self.session.get_entry_by_bundle_name(self.path.strip('/'))
         assert entry is not None, "entry not found"
         return entry
 
@@ -144,6 +144,7 @@ class AbCacheFilesystem(AbstractArchiveFileSystem):
     def dir_cache(self):
         cache = defaultdict(dict)
         for path, bundle in self.cache.abcache_index.bundles.items():
+            path = "/" + path
             cache.update(
                 {
                     dirname: {"name": dirname, "size": 0, "type": "directory"}
@@ -151,7 +152,7 @@ class AbCacheFilesystem(AbstractArchiveFileSystem):
                 }
             )
             cache[path] = {
-                "name": bundle.bundleName,
+                "name": path,
                 "size": bundle.fileSize,
                 "type": "file",
             }

--- a/sssekai/crypto/AssetBundle.py
+++ b/sssekai/crypto/AssetBundle.py
@@ -4,7 +4,7 @@ from typing import BinaryIO
 SEKAI_AB_MAGIC = b"\x10\x00\x00\x00"
 
 
-def decrypt_headaer_inplace(header: bytearray):
+def decrypt_header_inplace(header: bytearray):
     assert len(header) == 128
     for i in range(0, 128, 8):
         for j in range(5):
@@ -17,7 +17,7 @@ def decrypt(fin: BinaryIO, fout: BinaryIO = None) -> None:
         fout = BytesIO()
     magic = fin.read(4)
     if magic == SEKAI_AB_MAGIC:
-        fout.write(decrypt_headaer_inplace(bytearray(fin.read(128))))
+        fout.write(decrypt_header_inplace(bytearray(fin.read(128))))
         while block := fin.read(65536):
             fout.write(block)
     else:

--- a/sssekai/entrypoint/abdecrypt.py
+++ b/sssekai/entrypoint/abdecrypt.py
@@ -2,11 +2,15 @@ import os
 
 
 def main_abdecrypt(args):
-    from sssekai.crypto.AssetBundle import decrypt
+    from sssekai.crypto.AssetBundle import decrypt_iter
 
     tree = os.walk(args.indir)
     for root, dirs, files in tree:
         for fname in files:
             file = os.path.join(root, fname)
             if os.path.isfile(file):
-                decrypt(open(file, "rb"), open(os.path.join(args.outdir, fname), "wb"))
+                with open(file, "rb") as src:
+                    next_bytes = lambda nbytes: src.read(nbytes)
+                    with open(os.path.join(args.outdir, fname), "wb") as dest:
+                        for block in decrypt_iter(next_bytes):
+                            dest.write(block)

--- a/sssekai/entrypoint/abserver.py
+++ b/sssekai/entrypoint/abserver.py
@@ -1,0 +1,16 @@
+import os
+
+from sssekai.abcache import AbCache
+from sssekai.abcache.fs import AbCacheFilesystem
+from http.server import SimpleHTTPRequestHandler
+
+
+def main_abserver(args):
+    db_path = os.path.expanduser(args.db)
+    cache = AbCache()
+    cache.load(open(db_path, "rb"))
+    cache.update_download_headers()
+    fs = AbCacheFilesystem(cache)
+    # IDEA: Divert SimpleHTTPRequestHandler `os` filesystem calls to our FS and...
+    # Maybe not. I'll sit on this for now before I'd get better ideas.
+    pass

--- a/sssekai/entrypoint/abserver.py
+++ b/sssekai/entrypoint/abserver.py
@@ -1,16 +1,104 @@
-import os
+import os, logging, fsspec
+from shutil import copyfileobj
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+import fsspec.fuse
+from sssekai import __version__
 from sssekai.abcache import AbCache
 from sssekai.abcache.fs import AbCacheFilesystem
-from http.server import SimpleHTTPRequestHandler
+from rich import filesize
+
+logger = logging.getLogger("abserver")
+fs: AbCacheFilesystem = None
+
+
+class AbServerHTTPRequestHandler(BaseHTTPRequestHandler):
+    ENCODING = "utf-8"
+
+    def format_listing(self, path):
+        r = []
+        title = f"Directory listing for {path}"
+        r = (
+            f"<!DOCTYPE HTML>"
+            f'<html lang="en">'
+            f"<head>"
+            f'<meta charset="utf-8">'
+            f"<style>"
+            f"body {{ font-family: monospace; }}"
+            f"body {{ background-color: black; color: white; }}"
+            f"a {{ color: lightblue; }}"
+            f"</style>"
+            f"<title>{title}</title>"
+            f"</head>"
+            f"<body><h1>{title}</h1>"
+            f"<hr><ul>"
+            f'<li><a href="..">..</a></li>'
+        )
+        for entry in sorted(
+            fs.listdir(path), key=lambda x: (x["type"], x["name"], x["size"])
+        ):
+            # Directory then Files, then sorted lexically, then size
+            name = entry["name"]
+            nodename = name.split("/")[-1]
+            linkname = name
+            displayname = nodename
+            if fs.isdir(name):
+                linkname += "/"
+            else:
+                fsize = filesize.decimal(entry["size"])
+                displayname += f" ({fsize})"
+            r += '<li><a href="/%s">%s</a></li>' % (linkname, displayname)
+        r += "</ul><hr>"
+        r += "<i>sssekai v%s, %s</i>" % (__version__, fs.cache)
+        r += "</body></html>"
+        encoded = r.encode(self.ENCODING, "surrogateescape")
+        return encoded
+
+    def handle_path(self, path):
+        pass
+
+    def do_GET(self):
+        path = self.path.strip("/")
+        if not fs.exists(path):
+            self.send_error(404, "File not found")
+            return
+        else:
+            if fs.isfile(path):
+                self.send_response(200)
+                self.send_header("Content-type", "application/octet-stream")
+                self.send_header("Content-Length", fs.stat(path)["size"])
+                self.end_headers()
+                with fs.open(path, "rb") as f:
+                    copyfileobj(f, self.wfile)
+            else:
+                listing = self.format_listing(path)
+                self.send_response(200)
+                self.send_header("Content-type", "text/html")
+                self.send_header("Content-Length", len(listing))
+                self.end_headers()
+                self.wfile.write(listing)
 
 
 def main_abserver(args):
-    db_path = os.path.expanduser(args.db)
-    cache = AbCache()
-    cache.load(open(db_path, "rb"))
-    cache.update_download_headers()
-    fs = AbCacheFilesystem(cache)
-    # IDEA: Divert SimpleHTTPRequestHandler `os` filesystem calls to our FS and...
-    # Maybe not. I'll sit on this for now before I'd get better ideas.
-    pass
+    global fs
+    db_path = os.path.expanduser(os.path.normpath(args.db))
+    fs = fsspec.filesystem("abcache", fo=db_path)
+    if args.fuse:
+        fsspec.fuse.run(fs, "/", args.fuse, threads=True)
+    else:
+        with ThreadingHTTPServer(
+            (args.host, args.port), AbServerHTTPRequestHandler
+        ) as httpd:
+            try:
+                host, port = httpd.socket.getsockname()[:2]
+                url_host = f"[{host}]" if ":" in host else host
+                logger.info(
+                    f"Serving HTTP on {host} port {port} "
+                    f"> http://127.0.0.1:{port}/"
+                    f"> http://{url_host}:{port}/"
+                    f""
+                    f"Press Ctrl-C to stop."
+                )
+                httpd.serve_forever()
+            except Exception as e:
+                logger.info("Exiting. %s" % e)

--- a/sssekai/unity/AssetBundle.py
+++ b/sssekai/unity/AssetBundle.py
@@ -1,14 +1,14 @@
-from typing import BinaryIO
+from io import BytesIO
 from sssekai.crypto.AssetBundle import decrypt_iter
 
 from . import UnityPy, sssekai_get_unity_version
 from UnityPy import Environment
 
 
-def load_assetbundle(file: BinaryIO) -> Environment:
+def load_assetbundle(file: BytesIO) -> Environment:
     UnityPy.config.FALLBACK_VERSION_WARNED = True
     UnityPy.config.FALLBACK_UNITY_VERSION = sssekai_get_unity_version()
-    stream = BinaryIO()
+    stream = BytesIO()
     for block in decrypt_iter(lambda nbytes: file.read(nbytes)):
         stream.write(block)
     return UnityPy.load(stream)

--- a/sssekai/unity/AssetBundle.py
+++ b/sssekai/unity/AssetBundle.py
@@ -1,5 +1,5 @@
 from typing import BinaryIO
-from sssekai.crypto.AssetBundle import has_magic, decrypt
+from sssekai.crypto.AssetBundle import decrypt_iter
 
 from . import UnityPy, sssekai_get_unity_version
 from UnityPy import Environment
@@ -8,7 +8,7 @@ from UnityPy import Environment
 def load_assetbundle(file: BinaryIO) -> Environment:
     UnityPy.config.FALLBACK_VERSION_WARNED = True
     UnityPy.config.FALLBACK_UNITY_VERSION = sssekai_get_unity_version()
-    stream = file
-    if has_magic(file):
-        stream = decrypt(file)
+    stream = BinaryIO()
+    for block in decrypt_iter(lambda nbytes: file.read(nbytes)):
+        stream.write(block)
     return UnityPy.load(stream)


### PR DESCRIPTION
This enables us to *truly* retrive game assets ondemand without the absolute need to download them locally beforehands.
One can load assets with `UnityPy` directly from the servers, or mount them to their own systems thanks to `fusepy`