### PR TITLE
Add ab_version to config to overwrite in URL for ROW

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,9 +45,9 @@
                 "--app-region",
                 "jp",
                 "--app-version",
-                "5.0.0",
+                "5.0.2",
                 "--app-appHash",
-                "746b8607-0e65-489d-b060-a8986ba11b47"
+                "a87fc6e2-689c-b5a4-1608-968c93685dd8"
             ],
             "justMyCode": true
         },
@@ -63,9 +63,11 @@
                 "--app-region",
                 "tw",
                 "--app-version",
-                "3.4.0",   
+                "3.4.2",
                 "--app-appHash",
                 "a3015fe8-785f-27e1-fb8b-546a23c82c1f",
+                "--app-abVersion",
+                "3.4.0",
                 "--dump-user-data",
                 "~/.sssekai/tw_user"
             ],
@@ -83,9 +85,11 @@
                 "--app-region",
                 "kr",
                 "--app-version",
-                "3.4.0",   
+                "3.4.3",
                 "--app-appHash",
                 "a3015fe8-785f-27e1-fb8b-546a23c82c1f"
+                "--app-abVersion",
+                "3.4.0"
             ],
             "justMyCode": true
         },        
@@ -101,9 +105,9 @@
                 "--app-region",
                 "en",
                 "--app-version",
-                "3.1.0",
+                "3.2.0",
                 "--app-appHash",
-                "a892dc93-798e-4007-8d07-54cb13c9500a"
+                "1380836d-de9e-49a8-afe5-c52ba589c8c9"
             ],
             "justMyCode": true
         },
@@ -137,9 +141,9 @@
                 "--app-region",
                 "en",
                 "--app-version",
-                "3.1.0",
+                "3.2.0",
                 "--app-appHash",
-                "a892dc93-798e-4007-8d07-54cb13c9500a",
+                "1380836d-de9e-49a8-afe5-c52ba589c8c9",
                 "--dump-master-data",
                 "~/.sssekai/master_data"
             ],

--- a/sssekai/__main__.py
+++ b/sssekai/__main__.py
@@ -128,6 +128,12 @@ This crypto applies to:
         help="PJSK app hash. This is required unless --no-update is specified",
         default="",
     )
+    group.add_argument(
+        "--app-abVersion",
+        type=str,
+        help="PJSK AssetBundle URL version. This is used for ROW servers since it may differ.",
+        default=None,
+    )
     group = abcache_parser.add_argument_group("download options")
     group.add_argument(
         "--download-filter",

--- a/sssekai/abcache/__init__.py
+++ b/sssekai/abcache/__init__.py
@@ -71,6 +71,7 @@ class AbCacheConfig:
     app_version: str
     app_platform: str
     app_hash: str
+    ab_version: str = None # Override AB version in url for ROW
 
     auth_userID: str = None
     auth_credential: str = None  # JWT token for JP/EN, Base64 encoded JWT token for ROW
@@ -276,11 +277,11 @@ class AbCache(Session):
             case "en":
                 return f"https://assetbundle-info.sekai-en.com/api/version/{self.SEKAI_ASSET_VERSION}/os/{self.config.app_platform}"
             case "tw":  # NOTE: Android only
-                return f"https://lf16-mkovscdn-sg.bytedgame.com/obj/sf-game-alisg/gdl_app_5245/AssetBundle/{self.config.app_version}/Release/online/android49/AssetBundleInfoNew.json"
+                return f"https://lf16-mkovscdn-sg.bytedgame.com/obj/sf-game-alisg/gdl_app_5245/AssetBundle/{self.config.ab_version or self.config.app_version}/Release/online/android49/AssetBundleInfoNew.json"
             case "kr":  # NOTE: Android only
-                return f"https://lf16-mkkr.bytedgame.com/obj/sf-game-alisg/gdl_app_292248/AssetBundle/{self.config.app_version}/Release/kr_online/android53/AssetBundleInfoNew.json"
+                return f"https://lf16-mkkr.bytedgame.com/obj/sf-game-alisg/gdl_app_292248/AssetBundle/{self.config.ab_version or self.config.app_version}/Release/kr_online/android53/AssetBundleInfoNew.json"
             case "cn":  # NOTE: Android only
-                return f"https://lf3-mkcncdn-tos.dailygn.com/obj/sf-game-lf/gdl_app_5236/AssetBundle/{self.config.app_version}/Release/cn_online/android50/AssetBundleInfoNew.json"
+                return f"https://lf3-mkcncdn-tos.dailygn.com/obj/sf-game-lf/gdl_app_5236/AssetBundle/{self.config.ab_version or self.config.app_version}/Release/cn_online/android50/AssetBundleInfoNew.json"
             case _:
                 raise NotImplementedError
 
@@ -292,11 +293,11 @@ class AbCache(Session):
             case "en":
                 return f"https://assetbundle.sekai-en.com/"
             case "tw":  # NOTE: Android only
-                return f"https://lf16-mkovscdn-sg.bytedgame.com/obj/sf-game-alisg/gdl_app_5245/AssetBundle/{self.config.app_version}/Release/online/android1/"
+                return f"https://lf16-mkovscdn-sg.bytedgame.com/obj/sf-game-alisg/gdl_app_5245/AssetBundle/{self.config.ab_version or self.config.app_version}/Release/online/android1/"
             case "kr":  # NOTE: Android only
-                return f"https://lf16-mkkr.bytedgame.com/obj/sf-game-alisg/gdl_app_292248/AssetBundle/{self.config.app_version}/Release/kr_online/android1/"
+                return f"https://lf16-mkkr.bytedgame.com/obj/sf-game-alisg/gdl_app_292248/AssetBundle/{self.config.ab_version or self.config.app_version}/Release/kr_online/android1/"
             case "cn":  # NOTE: Android only
-                return f"https://lf3-j1gamecdn-cn.dailygn.com/obj/sf-game-lf/gdl_app_5236/AssetBundle/{self.config.app_version}/Release/cn_online/android1/"
+                return f"https://lf3-j1gamecdn-cn.dailygn.com/obj/sf-game-lf/gdl_app_5236/AssetBundle/{self.config.ab_version or self.config.app_version}/Release/cn_online/android1/"
             case _:
                 raise NotImplementedError
 

--- a/sssekai/entrypoint/abcache.py
+++ b/sssekai/entrypoint/abcache.py
@@ -85,6 +85,7 @@ def main_abcache(args):
         args.app_version,
         args.app_platform,
         args.app_appHash,
+        args.app_abVersion,
         args.auth_userId,
         args.auth_credential,
     )


### PR DESCRIPTION
Allow specifying a custom ab_version to use in the AB URLs for ROW (TW/KR/CN). This is due to the URL sometimes using a different version number.