### PR TITLE
Print error when API provides an error.

### DIFF
--- a/sssekai/abcache/__init__.py
+++ b/sssekai/abcache/__init__.py
@@ -445,11 +445,11 @@ class AbCache(Session):
             data = encrypt(data, SEKAI_APIMANAGER_KEYSETS[self.config.app_region])
         resp = self.request(method=method, url=url, data=data, **kwargs)
         if 400 <= resp.status_code < 600:
-            try: # print the error message provided by the API.
+            try: # log the error message provided by the API.
                 self.response_to_dict(resp)
-                print(resp)
+                logger.warn("%s" % resp)
             except:
-                print(resp)
+                logger.warn("%s" % resp)
             resp.raise_for_status()
         return resp
 

--- a/sssekai/abcache/__init__.py
+++ b/sssekai/abcache/__init__.py
@@ -444,7 +444,13 @@ class AbCache(Session):
             data = packb(data)
             data = encrypt(data, SEKAI_APIMANAGER_KEYSETS[self.config.app_region])
         resp = self.request(method=method, url=url, data=data, **kwargs)
-        resp.raise_for_status()
+        if 400 <= resp.status_code < 600:
+            try: # print the error message provided by the API.
+                self.response_to_dict(resp)
+                print(resp)
+            except:
+                print(resp)
+            resp.raise_for_status()
         return resp
 
     def response_to_dict(self, resp: Response, **kwargs):


### PR DESCRIPTION
This change just makes the function print the error provided by the API.

Sometimes, this can be useful (eg. 403 can have many reasons, and sometimes the API provides a clear reason).